### PR TITLE
feat: option to format commit list as markdown

### DIFF
--- a/src/branch_detective/__main__.py
+++ b/src/branch_detective/__main__.py
@@ -3,6 +3,7 @@ import click
 from datetime import datetime, timezone
 from typing import Optional
 
+from branch_detective.description import markdown_description
 from branch_detective.repository import RepositoryLens
 from branch_detective.compare import find_missing_by_message, find_missing_by_sha
 
@@ -59,12 +60,16 @@ branch.""")
     '-a', '--show-all', is_flag=True, default=False,
     help="automatically display all missing commits instead of paging"
 )
+@click.option(
+    '-m', '--markdown', is_flag=True, default=False,
+    help="create a markdown description from the commit messages"
+)
 @click.pass_context
 def main(
     ctx, source_branch: str, dest_branch: str,
     by_message: bool, ignore_merge: bool,
     since: str, before: str,
-    show_all: bool
+    show_all: bool, markdown: bool
 ):
     try:
         since_dt: Optional[datetime] = verify_date(since, '--since')
@@ -97,6 +102,13 @@ def main(
             source_log, dest_log, ignore_merge=ignore_merge,
             since=since_dt, before=before_dt
         )
+
+    if markdown:
+        overwrite("")
+        click.echo(
+            markdown_description(missing)
+        )
+        return
 
     overwrite("Elementary, dear Watson!", nl=True)
 

--- a/src/branch_detective/description.py
+++ b/src/branch_detective/description.py
@@ -1,0 +1,38 @@
+def is_using_conventional_commits(messages):
+    """Return false if any of the messages does not have a header line, meaning it contains
+    more than one line, but the second line is not blank.
+    """
+    for message in messages:
+        lines = message.split('\n')
+        # If any of the commits do not use header lines, assume we don't use conventional commits.
+        if len(lines) > 1 and lines[1] != "":
+            return False
+    return True
+
+def format_message_as_markdown(message, conventional):
+    """Format the message in markdown.
+
+    message - the raw commit message to format
+    conventional - if True, make the header line a real header; otherwise, separate commits with lines.
+    """
+    lines = message.split('\n')
+    if conventional:
+        lines[0] = f"## {lines[0]}"
+    else:
+        lines.append('\n-----')
+    return '\n'.join(lines)
+
+def markdown_description(commits):
+    """Convert list of commits to a string in markdown for use as a PR description.
+    """
+    messages = [
+        commit.message
+        for commit in commits
+    ]
+    conventional = is_using_conventional_commits(messages)
+    formatted_messages = [
+        format_message_as_markdown(message, conventional)
+        for message in messages
+    ]
+
+    return "\n\n".join(formatted_messages)


### PR DESCRIPTION
The -m or --markdown option formats the list of commits as Markdown, for copy/paste to a GitHub or GitLab description.

Closes #1 