### PR TITLE
feat: use current and default branches if none specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ is the **destination** branch, which you're search through for the commits in.
 If a commit is present in source, but not in destination, that commit is
 considered "missing".
 
+If you don't specify the source, the current branch will be used, and if you don't
+specify the destination, the local copy of the default branch (e.g. `main`) will be
+used. Thus, `branch-detective` without any arguments will display the commits present
+in the current branch, but absent from `main`.
+
 To keep things simple, Branch Detective will not tell you about commits
-present in the desintation branch, but not in the source branch. To see these,
+present in the destination branch, but not in the source branch. To see these,
 rerun Branch Detective with the branches swapped.
 
 ## Search by Message or SHA

--- a/src/branch_detective/__main__.py
+++ b/src/branch_detective/__main__.py
@@ -35,10 +35,12 @@ def verify_date(date: str, arg_name: str) -> Optional[datetime]:
 which commits are present on a SOURCE branch, but are absent from a DEST
 branch.""")
 @click.argument(
-    'source_branch'
+    'source_branch',
+    default=''
 )
 @click.argument(
-    'dest_branch'
+    'dest_branch',
+    default=''
 )
 @click.option(
     '--by-message/--by-sha', default=True,
@@ -83,6 +85,10 @@ def main(
 
     try:
         repo = RepositoryLens(source_branch, dest_branch)
+        # update branches to those detected by the repository
+        source_branch = repo.source_branch
+        dest_branch = repo.dest_branch
+        # get the commit logs
         source_log = repo.source_log
         dest_log = repo.dest_log
     except RuntimeError as e:

--- a/src/branch_detective/repository.py
+++ b/src/branch_detective/repository.py
@@ -8,7 +8,7 @@ class RepositoryLens:
     """Provides an interface to the repository in the current working
     directory."""
 
-    def __init__(self, source_branch: str, dest_branch: str):
+    def __init__(self, source_branch: str = '', dest_branch: str = ''):
         """Initializes a new RepositoryLens that works with the Git
         repository in the current working directory, and which specifically
         verifies and examines the source and destination branches specified
@@ -24,10 +24,22 @@ class RepositoryLens:
         except git.exc.InvalidGitRepositoryError:
             raise RuntimeError("This is not a valid Git repository.")
 
+        # use current branch if source is not specified
+        if source_branch == '':
+            source_branch = self.repo.active_branch.name
+
         # Verify the requested 'source' branch is valid.
         self.source_branch: str = source_branch
         if source_branch not in self.repo.heads:
             raise RuntimeError(f"Unknown source branch: {source_branch}")
+
+        # use default branch if dest is not specified
+        if dest_branch == '':
+            try:
+                default = [r.ref for r in self.repo.refs if r.name == 'origin/HEAD'][0]
+                dest_branch = default.name.split('/')[-1]
+            except IndexError as e:
+                raise RuntimeError(f"Could not determine default (origin/HEAD) branch.")
 
         # Verify the requested 'dest' branch is valid.
         self.dest_branch: str = dest_branch


### PR DESCRIPTION
If the user omits the source branch, use the current branch.
If the user omits the dest branch, use the default branch.
Resolves #3.